### PR TITLE
Render sheet option

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -112,5 +112,6 @@
   "npcImporter.settings.SetSize": "Auto-set token size",
   "npcImporter.settings.SetSizeHint": "Auto-sets the token size & scale according to creature size",
   "npcImporter.settings.AllAsSpecialAbilities": "Set all as Special Abilities",
-  "npcImporter.settings.AllAsSpecialAbilitiesHint": "If checked all Special Abilities (including weapons) will be imported as Special Abilities items. Otherwise, NPC Importer will try to identify Weapons/Armors and create them as appropriate Gear items"
+  "npcImporter.settings.AllAsSpecialAbilitiesHint": "If checked all Special Abilities (including weapons) will be imported as Special Abilities items. Otherwise, NPC Importer will try to identify Weapons/Armors and create them as appropriate Gear items",
+  "npcImporter.settings.RenderSheet": "Open the actors sheet after importing."
 }

--- a/scripts/settings/npcImporterSettings.js
+++ b/scripts/settings/npcImporterSettings.js
@@ -178,5 +178,12 @@ export class NpcImporterSettings {
       scope: 'world',
       type: String,
     });
+    game.settings.register(thisModule, 'renderSheet', {
+      name: game.i18n.localize('npcImporter.settings.RenderSheet'),
+      config: true,
+      scope: 'world',
+      type: Boolean,
+      default: false,
+    });
   }
 }

--- a/scripts/utils/foundryActions.js
+++ b/scripts/utils/foundryActions.js
@@ -147,12 +147,16 @@ export function getModuleSettings(settingKey) {
 
 export async function Import(actorData) {
   try {
-    await Actor.createDocuments([actorData]);
+    const actor = await Actor.createDocuments([actorData]);
     ui.notifications.info(
       game.i18n.format('npcImporter.HTML.ActorCreated', {
         actorName: actorData.name,
       })
     );
+    // Render actor sheet (optionally):
+    if (actor && game.settings.get(thisModule, 'renderSheet') === true) {
+      actor[0].sheet.render(true)
+    }
   } catch (error) {
     log(`Failed to import: ${error}`);
     ui.notifications.error(

--- a/scripts/utils/foundryActions.js
+++ b/scripts/utils/foundryActions.js
@@ -188,7 +188,7 @@ export async function DeleteActor(actorId) {
       game.i18n.format('npcImporter.HTML.DeleteActor', { actorId: actorId })
     );
   } catch (error) {
-    log(`Failed to delet actor: ${error}`);
+    log(`Failed to delete actor: ${error}`);
   }
 }
 

--- a/scripts/utils/foundryActions.js
+++ b/scripts/utils/foundryActions.js
@@ -147,7 +147,7 @@ export function getModuleSettings(settingKey) {
 
 export async function Import(actorData) {
   try {
-    const actor = await Actor.createDocuments([actorData]);
+    const actors = await Actor.createDocuments([actorData]);
     ui.notifications.info(
       game.i18n.format('npcImporter.HTML.ActorCreated', {
         actorName: actorData.name,
@@ -155,7 +155,7 @@ export async function Import(actorData) {
     );
     // Render actor sheet (optionally):
     if (actor && game.settings.get(thisModule, 'renderSheet') === true) {
-      actor[0].sheet.render(true)
+      actors[0].sheet.render(true)
     }
   } catch (error) {
     log(`Failed to import: ${error}`);


### PR DESCRIPTION
This introduces a new setting that - if activated - renders the sheet of the new actor after importing.
Foundry returns an array after creating. The importer however does not make use of the ability to create multiple actors at once. For this reason, I use `actor[0].sheet.render(true)` atm. Should the importer be changed to allow for batch importing, the code should be changed to either a loop or (what I'd preferably do) to not render any sheets to prevent opening of lots of sheets (which is known to slow down FVTT).