### PR TITLE
Adding hooks on import

### DIFF
--- a/scripts/utils/foundryActions.js
+++ b/scripts/utils/foundryActions.js
@@ -146,6 +146,8 @@ export function getModuleSettings(settingKey) {
 }
 
 export async function Import(actorData) {
+  //Throw a hook with the actorData before creation:
+  Hooks.call("npcImporter-preCreateActor", actorData);
   try {
     const actors = await Actor.createDocuments([actorData]);
     ui.notifications.info(
@@ -153,6 +155,8 @@ export async function Import(actorData) {
         actorName: actorData.name,
       })
     );
+    //Throw a hook containing the actors:
+    Hooks.call("npcImporter-ActorCreated", actors);
     // Render actor sheet (optionally):
     if (actors && game.settings.get(thisModule, 'renderSheet') === true) {
       actors[0].sheet.render(true);


### PR DESCRIPTION
Adds two hooks on import:

- `Hooks.call("npcImporter-preCreateActor", actorData);` is thrown right before the import containing the actors data used to import.
- `Hooks.call("npcImporter-ActorCreated", actors);` is thrown right after import containing the imported actror(s).

Allows other module developers to use these hooks for editing the actor data as desired (i.e. adding images, changing bio, etc.) Worst case it's only useful for me and takes two lines of code.