### PR TITLE
Button styles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,7 @@
 {
   "npcImporter.HTML.ActorImporter": "Actor Importer",
   "npcImporter.HTML.ImportTitle": "NPC Importer",
+  "npcImporter.HTML.StatBlockImporterTitle": "Stat Block Importer",
   "npcImporter.HTML.Import": "Import!",
   "npcImporter.HTML.Cancel": "Cancel",
   "npcImporter.HTML.ImportDesc": "Imports stats block from clipboard",

--- a/scripts/swadeNpcImporter.js
+++ b/scripts/swadeNpcImporter.js
@@ -29,11 +29,8 @@ Hooks.on('ready', async () => {
 
 Hooks.on('renderActorDirectory', async (app, html, data) => {
   if (game.users.get(game.userId).can('ACTOR_CREATE') == true) {
-    const npcImporterButton = $(
-      `<button style="margin: 4px; padding: 1px 6px;"><i class="fas fa-file-import"> ${game.i18n.localize(
-        'npcImporter.HTML.ActorImporter'
-      )}</i></button>`
-    );
+    const npcImporterButton = `<button style="width: calc(100% - 8px);"><i class="fas fa-file-import"></i>${game.i18n.localize('npcImporter.HTML.StatBlockImporterTitle')}</button>`;
+
     html.find('.directory-footer').append(npcImporterButton);
 
     npcImporterButton.click(() => {
@@ -112,7 +109,7 @@ function importerDialogue() {
         <form>
         <p>${game.i18n.localize('npcImporter.HTML.ImportDesc')}</p>
         <div class = "row">
-            <div class="column"> 
+            <div class="column">
                 <p>${game.i18n.localize('npcImporter.HTML.ActorType')}:</p>
                 <input type="radio" id="npc" name="actorType" value="npc" ${isChecked(
                   defaultData.actorType,
@@ -129,7 +126,7 @@ function importerDialogue() {
                   'npcImporter.settings.Character'
                 )}</lable>
             </div>
-            <div class="column"> 
+            <div class="column">
                 <p>${game.i18n.localize('npcImporter.HTML.Wildcard')}?</p>
                 <input type="radio" id="yes" name="isWildcard" value="true" ${isChecked(
                   defaultData.isWildcard,
@@ -146,7 +143,7 @@ function importerDialogue() {
                   'npcImporter.HTML.No'
                 )}</lable>
             </div>
-            <div class="column"> 
+            <div class="column">
                 <p>${game.i18n.localize('npcImporter.HTML.Disposition')}:</p>
                 <input type="radio" id="hostile" name="disposition" value="-1" ${isChecked(
                   defaultData.tokenData.disposition,
@@ -200,7 +197,7 @@ function importerDialogue() {
               }" />
             </div>
           </div>
-        </div> 
+        </div>
         <br>
         <div class="form-group slim">
           <label>${game.i18n.localize('npcImporter.HTML.SaveFolder')} </label>

--- a/scripts/swadeNpcImporter.js
+++ b/scripts/swadeNpcImporter.js
@@ -29,11 +29,15 @@ Hooks.on('ready', async () => {
 
 Hooks.on('renderActorDirectory', async (app, html, data) => {
   if (game.users.get(game.userId).can('ACTOR_CREATE') == true) {
-    const npcImporterButton = `<button style="width: calc(100% - 8px);"><i class="fas fa-align-left"></i>${game.i18n.localize('npcImporter.HTML.StatBlockImporterTitle')}</button>`;
+    const npcImporterButton = $(
+      `<button style="width: calc(100% - 8px);"><i class="fas fa-align-left"></i>${game.i18n.localize(
+        'npcImporter.HTML.StatBlockImporterTitle'
+      )}</button>`
+    );
 
     html.find('.directory-footer').append(npcImporterButton);
 
-    npcImporterButton.click(() => {
+    npcImporterButton.on('click', () => {
       new Dialog({
         title: game.i18n.localize('npcImporter.HTML.ImportTitle'),
         content: importerDialogue(),

--- a/scripts/swadeNpcImporter.js
+++ b/scripts/swadeNpcImporter.js
@@ -29,7 +29,7 @@ Hooks.on('ready', async () => {
 
 Hooks.on('renderActorDirectory', async (app, html, data) => {
   if (game.users.get(game.userId).can('ACTOR_CREATE') == true) {
-    const npcImporterButton = `<button style="width: calc(100% - 8px);"><i class="fas fa-file-import"></i>${game.i18n.localize('npcImporter.HTML.StatBlockImporterTitle')}</button>`;
+    const npcImporterButton = `<button style="width: calc(100% - 8px);"><i class="fas fa-align-left"></i>${game.i18n.localize('npcImporter.HTML.StatBlockImporterTitle')}</button>`;
 
     html.find('.directory-footer').append(npcImporterButton);
 


### PR DESCRIPTION
- Fixes markup of button to display with the correct font (i.e. moves the label outside of the Font Awesome element).
- Fixes CSS styles to fit button within the sidebar fully by adjusting the width to `calc(100% - 8px)` to account for the margins Foundry applies.
- Changes icon to `fa-align-left` to represent a stat block.
- Suggests new button title (EN) for clarity of what the button actually does.
  - Helps to identify it more clearly if the Savaged.us Importer module is also active.
  - Translations are needed for this new title.